### PR TITLE
Fix type in boards.py

### DIFF
--- a/mesact/src/libmesact/boards.py
+++ b/mesact/src/libmesact/boards.py
@@ -53,7 +53,7 @@ def boardChanged(parent):
 		parent.port_0_channels_lb.clear()
 		parent.port_1_channels_lb.clear()
 		parent.find_ip_board_pb.setEnabled(True)
-		parent.board_info_pte..clear()
+		parent.board_info_pte.clear()
 
 		if board == '5i24': # PCI IDC50
 			parent.hal_name = '5i24'


### PR DESCRIPTION
Fix typo on line 56 in call to parent.board_info_pte.clear().  I found this when I downloaded and installed the latest .deb today when it errored out upon running.